### PR TITLE
Fix issue with call to reduce in sorted-coll? sample and add Intellij…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea
+*.iml

--- a/src/test_check_playground/fn_specs.clj
+++ b/src/test_check_playground/fn_specs.clj
@@ -6,7 +6,7 @@
   (not (pos? (reduce
               (fn [r [a b]]
                 (if (pos? r)
-                  (reduce r)
+                  r
                   (compare a b)))
               -1
               (partition 2 1 s)))))


### PR DESCRIPTION
… project files to the .gitignore for Cursive users

For `sorted-coll?` the expression `(reduce r)` results in an error anytime it's called. Should this just be `r` instead?

`(sorted-coll? [2 3 1 4])` results in an error that looks like this: "Wrong number of args (1) passed to: clojure.core/reduce" 